### PR TITLE
fix invalid printf formats

### DIFF
--- a/sample/test.ml
+++ b/sample/test.ml
@@ -58,11 +58,13 @@ TEST "sexp conversion" =
 TEST =
   sprintf !"%d %%{foo" 3
   = "3 %{foo"
+(*
 TEST =
   sprintf !"%d %.2%{foo" 3
   = "3 %{foo"
+*)
 TEST =
-  sprintf !"%d %.2%%{Time}" 3 (Time.now ())
+  sprintf !"%d %%%{Time}" 3 (Time.now ())
   = "3 %[Time.to_string (Time.now ())]"
 TEST =
   sprintf !"%d %%{%{Time}" 3 (Time.now ())


### PR DESCRIPTION
The test file of custom_printf contains an "invalid" format. Invalid formats are nonsensical formats that were accepted up to 4.01.0, are still accepted in 4.02.0 but sometimes with different semantics, and will be statically rejected by 4.03.0. This patch removes one test that contains such a format and changes another to make the format valid.
